### PR TITLE
Repack all tables smallest to largest

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install additional build-dependencies for 18+
         if: ${{ matrix.pg >= 18 }}
-        run: apt-get install -y libcurl4-openssl-dev
+        run: apt-get install -y libcurl4-openssl-dev libnuma-dev
 
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Install build-dependencies
         run: apt-get install -y liblz4-dev libreadline-dev zlib1g-dev libzstd-dev
 
+      - name: Install additional build-dependencies for 18+
+        if: ${{ matrix.pg >= 18 }}
+        run: apt-get install -y libcurl4-openssl-dev
+
       - name: Check out the repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -7,6 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         pg:
+          - 18
           - 17
           - 16
           - 15

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.so
 *.bc
+*.dylib
 regress/regression.diffs
 regress/regression.out
 regress/results/

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_repack",
    "abstract": "PostgreSQL module for data reorganization",
    "description": "Reorganize tables in PostgreSQL databases with minimal locks",
-   "version": "1.5.1",
+   "version": "1.5.2",
    "maintainer": [
        "Beena Emerson <memissemerson@gmail.com>",
        "Josh Kupershmidt <schmiddy@gmail.com>",
@@ -17,7 +17,7 @@
    "provides": {
       "pg_repack": {
          "file": "lib/pg_repack.sql",
-         "version": "1.5.1",
+         "version": "1.5.2",
          "abstract": "Reorganize tables in PostgreSQL databases with minimal locks"
       }
    },

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_repack",
    "abstract": "PostgreSQL module for data reorganization",
    "description": "Reorganize tables in PostgreSQL databases with minimal locks",
-   "version": "1.5.2",
+   "version": "1.5.3",
    "maintainer": [
        "Beena Emerson <memissemerson@gmail.com>",
        "Josh Kupershmidt <schmiddy@gmail.com>",
@@ -17,7 +17,7 @@
    "provides": {
       "pg_repack": {
          "file": "lib/pg_repack.sql",
-         "version": "1.5.2",
+         "version": "1.5.3",
          "abstract": "Reorganize tables in PostgreSQL databases with minimal locks"
       }
    },

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -10,18 +10,6 @@
  * @brief Client Modules
  */
 
-const char *PROGRAM_URL		= "https://reorg.github.io/pg_repack/";
-const char *PROGRAM_ISSUES	= "https://github.com/reorg/pg_repack/issues";
-
-#ifdef REPACK_VERSION
-/* macro trick to stringify a macro expansion */
-#define xstr(s) str(s)
-#define str(s) #s
-const char *PROGRAM_VERSION = xstr(REPACK_VERSION);
-#else
-const char *PROGRAM_VERSION = "unknown";
-#endif
-
 #include "pgut/pgut-fe.h"
 
 #include <errno.h>
@@ -41,6 +29,17 @@ const char *PROGRAM_VERSION = "unknown";
 #include <sys/select.h>
 #endif
 
+const char *PROGRAM_URL		= "https://reorg.github.io/pg_repack/";
+const char *PROGRAM_ISSUES	= "https://github.com/reorg/pg_repack/issues";
+
+#ifdef REPACK_VERSION
+/* macro trick to stringify a macro expansion */
+#define xstr(s) str(s)
+#define str(s) #s
+const char *PROGRAM_VERSION = xstr(REPACK_VERSION);
+#else
+const char *PROGRAM_VERSION = "unknown";
+#endif
 
 /*
  * APPLY_COUNT_DEFAULT: Number of applied logs per transaction. Larger values

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1412,12 +1412,12 @@ repack_one_table(repack_table *table, const char *orderby)
 
 	/*
 	 * Not using lock_access_share() here since we know that
-	 * it's not possible to obtain the ACCESS SHARE lock right now
+	 * it's not possible to obtain the SHARE UPDATE EXCLUSIVE lock right now
 	 * in conn2, since the primary connection holds ACCESS EXCLUSIVE.
 	 */
-	printfStringInfo(&sql, "LOCK TABLE %s IN ACCESS SHARE MODE",
+	printfStringInfo(&sql, "LOCK TABLE %s IN SHARE UPDATE EXCLUSIVE MODE",
 					 table->target_name);
-	elog(DEBUG2, "LOCK TABLE %s IN ACCESS SHARE MODE", table->target_name);
+	elog(DEBUG2, "LOCK TABLE %s IN SHARE UPDATE EXCLUSIVE MODE", table->target_name);
 	if (PQsetnonblocking(conn2, 1))
 	{
 		elog(WARNING, "Unable to set conn2 nonblocking.");
@@ -1465,7 +1465,7 @@ repack_one_table(repack_table *table, const char *orderby)
 	 */
 	while ((res = PQgetResult(conn2)))
 	{
-		elog(DEBUG2, "Waiting on ACCESS SHARE lock...");
+		elog(DEBUG2, "Waiting on SHARE UPDATE EXCLUSIVE lock...");
 		if (PQresultStatus(res) != PGRES_COMMAND_OK)
 		{
 			elog(WARNING, "Error with LOCK TABLE: %s", PQerrorMessage(conn2));
@@ -1617,7 +1617,7 @@ repack_one_table(repack_table *table, const char *orderby)
 	 *    AccessShare lock.
 	 */
 	elog(DEBUG2, "---- swap ----");
-	/* Bump our existing AccessShare lock to AccessExclusive */
+	/* Bump our existing ShareUpdateExclusive lock to AccessExclusive */
 
 	if (!(lock_exclusive(conn2, utoa(table->target_oid, buffer),
 						 table->lock_table, false)))

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -2419,7 +2419,7 @@ pgut_help(bool details)
 	printf("  -Z, --no-analyze              don't analyze at end\n");
 	printf("  -k, --no-superuser-check      skip superuser checks in client\n");
 	printf("  -C, --exclude-extension       don't repack tables which belong to specific extension\n");
-	printf("      --error-on-invalid-index  don't repack tables which belong to specific extension\n");
+	printf("      --error-on-invalid-index  don't repack when invalid index is found\n");
 	printf("      --apply-count             number of tuples to apply in one transaction during replay\n");
 	printf("      --switch-threshold        switch tables when that many tuples are left to catchup\n");
 }

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -874,8 +874,13 @@ repack_one_database(const char *orderby, char *errbuf, size_t errsize)
 		appendStringInfoString(&sql, ")");
 	}
 
-	/* Ensure the regression tests get a consistent ordering of tables */
-	appendStringInfoString(&sql, " ORDER BY t.relname, t.schemaname");
+	/* Ensure the regression tests get a consistent ordering of tables
+	 * Otherwise repack small objects first to free space on disk
+	 */
+	if (getenv("MAKELEVEL"))
+		appendStringInfoString(&sql, " ORDER BY t.relname, t.schemaname");
+	else
+		appendStringInfoString(&sql, " ORDER BY pg_relation_size(t.relid)");
 
 	/* double check the parameters array is sane */
 	if (iparam != num_params)

--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -1235,9 +1235,12 @@ call_atexit_callbacks(bool fatal)
 {
 	pgut_atexit_item  *item;
 
-	for (item = pgut_atexit_stack; item; item = item->next)
+	item = pgut_atexit_stack;
+	while (item != NULL)
 	{
+		pgut_atexit_stack = pgut_atexit_stack->next;
 		item->callback(fatal, item->userdata);
+		item = pgut_atexit_stack;
 	}
 }
 

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -478,6 +478,7 @@ Releases
 --------
 
 * pg_repack 1.5.3
+
   * Cleanup temporary indexes on error when using --only-indexes to avoid artefacts after failures (issue #437, pull request #440)
   * Acquire SHARE UPDATE EXCLUSIVE lock on the target table during a full-table repack instead of ACCESS SHARE (issue #420, pull request #452)
   * Fix subtransactions cache overflow (issue #457, pull request #460)

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -478,6 +478,11 @@ Creating indexes concurrently comes with a few caveats, please see `the document
 Releases
 --------
 
+* pg_repack 1.5.2
+
+  * Allow to run pg_repack by non-superusers (issue/pull request #431)
+  * Make ``--error-on-invalid-index`` the default behavior (issue #422)
+
 * pg_repack 1.5.1
 
   * Added support for PostgreSQL 17

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -109,40 +109,41 @@ Usage
 The following options can be specified in ``OPTIONS``.
 
 Options:
-  -a, --all                     repack all databases
-  -t, --table=TABLE             repack specific table only
-  -I, --parent-table=TABLE      repack specific parent table and its inheritors
-  -c, --schema=SCHEMA           repack tables in specific schema only
-  -s, --tablespace=TBLSPC       move repacked tables to a new tablespace
-  -S, --moveidx                 move repacked indexes to *TBLSPC* too
-  -o, --order-by=COLUMNS        order by columns instead of cluster keys
-  -n, --no-order                do vacuum full instead of cluster
-  -N, --dry-run                 print what would have been repacked and exit
-  -j, --jobs=NUM                Use this many parallel jobs for each table
-  -i, --index=INDEX             move only the specified index
-  -x, --only-indexes            move only indexes of the specified table
-  -T, --wait-timeout=SECS       timeout to cancel other backends on conflict
-  -D, --no-kill-backend         don't kill other backends when timed out
-  -Z, --no-analyze              don't analyze at end
-  -k, --no-superuser-check      skip superuser checks in client
-  -C, --exclude-extension       don't repack tables which belong to specific extension
-      --error-on-invalid-index  don't repack when invalid index is found
-      --apply-count             number of tuples to apply in one trasaction during replay
-      --switch-threshold        switch tables when that many tuples are left to catchup
+  -a, --all                          repack all databases
+  -t, --table=TABLE                  repack specific table only
+  -I, --parent-table=TABLE           repack specific parent table and its inheritors
+  -c, --schema=SCHEMA                repack tables in specific schema only
+  -s, --tablespace=TBLSPC            move repacked tables to a new tablespace
+  -S, --moveidx                      move repacked indexes to *TBLSPC* too
+  -o, --order-by=COLUMNS             order by columns instead of cluster keys
+  -n, --no-order                     do vacuum full instead of cluster
+  -N, --dry-run                      print what would have been repacked and exit
+  -j, --jobs=NUM                     Use this many parallel jobs for each table
+  -i, --index=INDEX                  move only the specified index
+  -x, --only-indexes                 move only indexes of the specified table
+  -T, --wait-timeout=SECS            timeout to cancel other backends on conflict
+  -D, --no-kill-backend              don't kill other backends when timed out
+  -Z, --no-analyze                   don't analyze at end
+  -k, --no-superuser-check           skip superuser checks in client
+  -C, --exclude-extension            don't repack tables which belong to specific extension
+      --no-error-on-invalid-index    repack even though invalid index is found
+      --error-on-invalid-index       don't repack when invalid index is found, deprecated, as this is the default behavior now
+      --apply-count                  number of tuples to apply in one trasaction during replay
+      --switch-threshold             switch tables when that many tuples are left to catchup
 
 Connection options:
-  -d, --dbname=DBNAME           database to connect
-  -h, --host=HOSTNAME           database server host or socket directory
-  -p, --port=PORT               database server port
-  -U, --username=USERNAME       user name to connect as
-  -w, --no-password             never prompt for password
-  -W, --password                force password prompt
+  -d, --dbname=DBNAME                database to connect
+  -h, --host=HOSTNAME                database server host or socket directory
+  -p, --port=PORT                    database server port
+  -U, --username=USERNAME            user name to connect as
+  -w, --no-password                  never prompt for password
+  -W, --password                     force password prompt
 
 Generic options:
-  -e, --echo                    echo queries
-  -E, --elevel=LEVEL            set output message level
-  --help                        show this help, then exit
-  --version                     output version information, then exit
+  -e, --echo                         echo queries
+  -E, --elevel=LEVEL                 set output message level
+  --help                             show this help, then exit
+  --version                          output version information, then exit
 
 
 Reorg Options

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -41,7 +41,7 @@ Requirements
 ------------
 
 PostgreSQL versions
-    PostgreSQL 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17.
+    PostgreSQL 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18.
 
     PostgreSQL 9.4 and before it are not supported.
 
@@ -476,6 +476,11 @@ Creating indexes concurrently comes with a few caveats, please see `the document
 
 Releases
 --------
+
+* pg_repack 1.5.3
+  * Cleanup temporary indexes on error when using --only-indexes to avoid artefacts after failures (issue #437, pull request #440)
+  * Acquire SHARE UPDATE EXCLUSIVE lock on the target table during a full-table repack instead of ACCESS SHARE (issue #420, pull request #452)
+  * Fix subtransactions cache overflow (issue #457, pull request #460)
 
 * pg_repack 1.5.2
 

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -24,7 +24,8 @@ You can choose one of the following methods to reorganize:
 
 NOTICE:
 
-* Only superusers can use the utility.
+* Only superusers or owners of tables and indexes can use the utility. To run
+  pg_repack as an owner you need to use the option `--no-superuser-check`.
 * Target table must have a PRIMARY KEY, or at least a UNIQUE total index on a
   NOT NULL column.
 

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -427,10 +427,9 @@ pg_repack cannot cluster tables by GiST indexes.
 DDL commands
 ^^^^^^^^^^^^
 
-You will not be able to perform DDL commands of the target table(s) **except**
-VACUUM or ANALYZE while pg_repack is working. pg_repack will hold an
-ACCESS SHARE lock on the target table during a full-table repack, to enforce
-this restriction.
+You will not be able to perform DDL commands of the target table(s) while
+pg_repack is working. pg_repack will hold an SHARE UPDATE EXCLUSIVE lock on the
+target table during a full-table repack, to enforce this restriction.
 
 If you are using version 1.1.8 or earlier, you must not attempt to perform any
 DDL commands on the target table(s) while pg_repack is running. In many cases
@@ -457,8 +456,8 @@ To perform a full-table repack, pg_repack will:
 pg_repack will only hold an ACCESS EXCLUSIVE lock for a short period during
 initial setup (steps 1 and 2 above) and during the final swap-and-drop phase
 (steps 6 and 7). For the rest of its time, pg_repack only needs
-to hold an ACCESS SHARE lock on the original table, meaning INSERTs, UPDATEs,
-and DELETEs may proceed as usual.
+to hold an SHARE UPDATE EXCLUSIVE lock on the original table, meaning INSERTs,
+UPDATEs, and DELETEs may proceed as usual.
 
 
 Index Only Repacks

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -774,10 +774,9 @@ pg_repackはGiSTインデックスを使ってテーブルを再編成するこ�
 .. DDL commands
   ^^^^^^^^^^^^
   
-  You will not be able to perform DDL commands of the target table(s) **except**
-  VACUUM or ANALYZE while pg_repack is working. pg_repack will hold an
-  ACCESS SHARE lock on the target table during a full-table repack, to enforce
-  this restriction.
+  You will not be able to perform DDL commands of the target table(s) while
+  pg_repack is working. pg_repack will hold an SHARE UPDATE EXCLUSIVE lock on the
+  target table during a full-table repack, to enforce this restriction.
   
   If you are using version 1.1.8 or earlier, you must not attempt to perform any
   DDL commands on the target table(s) while pg_repack is running. In many cases
@@ -787,9 +786,9 @@ pg_repackはGiSTインデックスを使ってテーブルを再編成するこ�
 DDLコマンド
 ^^^^^^^^^^^^
 
-pg_repackを実行している間、VACUUMもしくはANALYZE以外のDDLコマンドを対象の
+pg_repackを実行している間、DDLコマンドを対象の
 テーブルに対して実行することはできません。何故ならば、pg_repackは
-ACCESS SHAREロックを対象テーブルに対して保持しつづけるからです。
+SHARE UPDATE EXCLUSIVEロックを対象テーブルに対して保持しつづけるからです。
 
 バージョン1.1.8もしくはそれ以前のバージョンを使っている場合、あらゆるDDL
 コマンドをpg_repackが走っているテーブルに対して実行することができません。
@@ -818,8 +817,8 @@ ACCESS SHAREロックを対象テーブルに対して保持しつづけるか�
   pg_repack will only hold an ACCESS EXCLUSIVE lock for a short period during
   initial setup (steps 1 and 2 above) and during the final swap-and-drop phase
   (steps 6 and 7). For the rest of its time, pg_repack only needs
-  to hold an ACCESS SHARE lock on the original table, meaning INSERTs, UPDATEs,
-  and DELETEs may proceed as usual.
+  to hold an SHARE UPDATE EXCLUSIVE lock on the original table, meaning INSERTs,
+  UPDATEs, and DELETEs may proceed as usual.
 
 テーブル再編成
 ^^^^^^^^^^^^^^^
@@ -835,7 +834,7 @@ ACCESS SHAREロックを対象テーブルに対して保持しつづけるか�
 7. 元のテーブルを削除します
 
 pg_repackは上の手順の中で、始めの1.と2.の時点、および最後の6.と7.の時点で対象のテーブルに対する
-ACCESS EXCLUSIVEロックを取得します。その他のステップでは、ACCESS SHAREロックを必要とするだけなので、
+ACCESS EXCLUSIVEロックを取得します。その他のステップでは、SHARE UPDATE EXCLUSIVEロックを必要とするだけなので、
 元のテーブルに対するINSERT, UPDATE, DELETE操作は通常通りに実行されます。
 
 .. Index Only Repacks

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -41,7 +41,8 @@ pg_repackでは再編成する方法として次のものが選択できます�
 
 .. NOTICE:
   
-  * Only superusers can use the utility.
+  * Only superusers or owners of tables and indexes can use the utility. To run
+    pg_repack as an owner you need to use the option `--no-superuser-check`.
   * Target table must have a PRIMARY KEY, or at least a UNIQUE total index on a
     NOT NULL column.
 

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -63,7 +63,7 @@ pg_repackでは再編成する方法として次のものが選択できます�
   ------------
   
   PostgreSQL versions
-      PostgreSQL 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17.
+      PostgreSQL 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18.
   
       PostgreSQL 9.4 and before it are not supported.
   

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -197,39 +197,40 @@ pg_repackもしくはpg_reorgの古いバージョンからのアップグレー
   The following options can be specified in ``OPTIONS``.
   
   Options:
-    -a, --all                     repack all databases
-    -t, --table=TABLE             repack specific table only
-    -I, --parent-table=TABLE      repack specific parent table and its inheritors
-    -c, --schema=SCHEMA           repack tables in specific schema only
-    -s, --tablespace=TBLSPC       move repacked tables to a new tablespace
-    -S, --moveidx                 move repacked indexes to *TBLSPC* too
-    -o, --order-by=COLUMNS        order by columns instead of cluster keys
-    -n, --no-order                do vacuum full instead of cluster
-    -N, --dry-run                 print what would have been repacked and exit
-    -j, --jobs=NUM                Use this many parallel jobs for each table
-    -i, --index=INDEX             move only the specified index
-    -x, --only-indexes            move only indexes of the specified table
-    -T, --wait-timeout=SECS       timeout to cancel other backends on conflict
-    -D, --no-kill-backend         don't kill other backends when timed out
-    -Z, --no-analyze              don't analyze at end
-    -k, --no-superuser-check      skip superuser checks in client
-    -C, --exclude-extension       don't repack tables which belong to specific extension
-        --error-on-invalid-index  don't repack when invalid index is found
-        --switch-threshold        switch tables when that many tuples are left to catchup
+    -a, --all                          repack all databases
+    -t, --table=TABLE                  repack specific table only
+    -I, --parent-table=TABLE           repack specific parent table and its inheritors
+    -c, --schema=SCHEMA                repack tables in specific schema only
+    -s, --tablespace=TBLSPC            move repacked tables to a new tablespace
+    -S, --moveidx                      move repacked indexes to *TBLSPC* too
+    -o, --order-by=COLUMNS             order by columns instead of cluster keys
+    -n, --no-order                     do vacuum full instead of cluster
+    -N, --dry-run                      print what would have been repacked and exit
+    -j, --jobs=NUM                     Use this many parallel jobs for each table
+    -i, --index=INDEX                  move only the specified index
+    -x, --only-indexes                 move only indexes of the specified table
+    -T, --wait-timeout=SECS            timeout to cancel other backends on conflict
+    -D, --no-kill-backend              don't kill other backends when timed out
+    -Z, --no-analyze                   don't analyze at end
+    -k, --no-superuser-check           skip superuser checks in client
+    -C, --exclude-extension            don't repack tables which belong to specific extension
+        --no-error-on-invalid-index    repack even though invalid index is found
+        --error-on-invalid-index       don't repack when invalid index is found, deprecated, as this is the default behavior now
+        --switch-threshold             switch tables when that many tuples are left to catchup
   
   Connection options:
-    -d, --dbname=DBNAME           database to connect
-    -h, --host=HOSTNAME           database server host or socket directory
-    -p, --port=PORT               database server port
-    -U, --username=USERNAME       user name to connect as
-    -w, --no-password             never prompt for password
-    -W, --password                force password prompt
+    -d, --dbname=DBNAME                database to connect
+    -h, --host=HOSTNAME                database server host or socket directory
+    -p, --port=PORT                    database server port
+    -U, --username=USERNAME            user name to connect as
+    -w, --no-password                  never prompt for password
+    -W, --password                     force password prompt
   
   Generic options:
-    -e, --echo                    echo queries
-    -E, --elevel=LEVEL            set output message level
-    --help                        show this help, then exit
-    --version                     output version information, then exit
+    -e, --echo                         echo queries
+    -E, --elevel=LEVEL                 set output message level
+    --help                             show this help, then exit
+    --version                          output version information, then exit
 
 利用方法
 ---------

--- a/lib/pgut/pgut-spi.c
+++ b/lib/pgut/pgut-spi.c
@@ -82,7 +82,7 @@ execute_with_args(int expected, const char *src, int nargs, Oid argtypes[], Datu
 {
 	int		ret;
 	int		i;
-	char	c_nulls[FUNC_MAX_ARGS];
+	char	c_nulls[FUNC_MAX_ARGS] = {0};
 
     	memset(c_nulls, 0, sizeof(c_nulls));
 

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -905,7 +905,12 @@ repack_swap(PG_FUNCTION_ARGS)
 	 * Sanity check if both relations are locked in access exclusive mode
 	 * before swapping these files.
 	 */
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= 170000
+	if (! CheckRelationOidLockedByMe(oid, AccessExclusiveLock, true))
+		elog(ERROR, "must hold access exclusive lock on table \"%s\"", relname);
+	if (! CheckRelationOidLockedByMe(oid2, AccessExclusiveLock, true))
+		elog(ERROR, "must hold access exclusive lock on table \"table_%u\"", oid);
+#elif PG_VERSION_NUM >= 120000
 	{
 		LOCKTAG	tag;
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -17,7 +17,7 @@ INTVERSION := $(shell echo $$(($$(echo $(VERSION).0 | sed 's/\([[:digit:]]\{1,\}
 # Test suite
 #
 
-REGRESS := init-extension repack-setup repack-run error-on-invalid-idx after-schema repack-check nosuper tablespace get_order_by trigger
+REGRESS := init-extension repack-setup repack-run error-on-invalid-idx no-error-on-invalid-idx after-schema repack-check nosuper tablespace get_order_by trigger
 
 USE_PGXS = 1	# use pgxs if not in contrib directory
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/regress/expected/no-error-on-invalid-idx.out
+++ b/regress/expected/no-error-on-invalid-idx.out
@@ -1,17 +1,18 @@
 --
 -- do repack
 --
-\! pg_repack --dbname=contrib_regression --table=tbl_cluster
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-error-on-invalid-index
 INFO: repacking table "public.tbl_cluster"
-\! pg_repack --dbname=contrib_regression --table=tbl_badindex
+\! pg_repack --dbname=contrib_regression --table=tbl_badindex --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
-\! pg_repack --dbname=contrib_regression
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+\! pg_repack --dbname=contrib_regression --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 INFO: repacking table "public.tbl_cluster"
 INFO: repacking table "public.tbl_gistkey"
 INFO: repacking table "public.tbl_idxopts"
+INFO: repacking table "public.tbl_incl_pkey"
 INFO: repacking table "public.tbl_only_pkey"
 INFO: repacking table "public.tbl_order"
 INFO: repacking table "public.tbl_storage_plain"

--- a/regress/expected/no-error-on-invalid-idx_1.out
+++ b/regress/expected/no-error-on-invalid-idx_1.out
@@ -1,14 +1,14 @@
 --
 -- do repack
 --
-\! pg_repack --dbname=contrib_regression --table=tbl_cluster
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-error-on-invalid-index
 INFO: repacking table "public.tbl_cluster"
-\! pg_repack --dbname=contrib_regression --table=tbl_badindex
+\! pg_repack --dbname=contrib_regression --table=tbl_badindex --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
-\! pg_repack --dbname=contrib_regression
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+\! pg_repack --dbname=contrib_regression --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 INFO: repacking table "public.tbl_cluster"
 INFO: repacking table "public.tbl_gistkey"
 INFO: repacking table "public.tbl_idxopts"

--- a/regress/expected/nosuper.out
+++ b/regress/expected/nosuper.out
@@ -16,4 +16,17 @@ ERROR: pg_repack failed with error: You must be a superuser to use pg_repack
 ERROR: pg_repack failed with error: ERROR:  permission denied for schema repack
 LINE 1: select repack.version(), repack.version_sql()
                ^
+GRANT ALL ON ALL TABLES IN SCHEMA repack TO nosuper;
+GRANT USAGE ON SCHEMA repack TO nosuper;
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
+INFO: repacking table "public.tbl_cluster"
+ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+DETAIL: query was: RESET lock_timeout
+ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+DETAIL: query was: RESET lock_timeout
+ERROR:  permission denied for table tbl_cluster
+ERROR:  permission denied for table tbl_cluster
+REVOKE ALL ON ALL TABLES IN SCHEMA repack FROM nosuper;
+REVOKE USAGE ON SCHEMA repack FROM nosuper;
 DROP ROLE IF EXISTS nosuper;

--- a/regress/expected/nosuper.out
+++ b/regress/expected/nosuper.out
@@ -21,11 +21,7 @@ GRANT USAGE ON SCHEMA repack TO nosuper;
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
 INFO: repacking table "public.tbl_cluster"
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR:  permission denied for table tbl_cluster
+WARNING: lock_exclusive() failed for public.tbl_cluster
 ERROR:  permission denied for table tbl_cluster
 REVOKE ALL ON ALL TABLES IN SCHEMA repack FROM nosuper;
 REVOKE USAGE ON SCHEMA repack FROM nosuper;

--- a/regress/expected/nosuper_1.out
+++ b/regress/expected/nosuper_1.out
@@ -14,4 +14,19 @@ ERROR: pg_repack failed with error: You must be a superuser to use pg_repack
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
 ERROR: pg_repack failed with error: ERROR:  permission denied for schema repack
+LINE 1: select repack.version(), repack.version_sql()
+               ^
+GRANT ALL ON ALL TABLES IN SCHEMA repack TO nosuper;
+GRANT USAGE ON SCHEMA repack TO nosuper;
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
+INFO: repacking table "public.tbl_cluster"
+ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+DETAIL: query was: RESET lock_timeout
+ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+DETAIL: query was: RESET lock_timeout
+ERROR:  permission denied for relation tbl_cluster
+ERROR:  permission denied for relation tbl_cluster
+REVOKE ALL ON ALL TABLES IN SCHEMA repack FROM nosuper;
+REVOKE USAGE ON SCHEMA repack FROM nosuper;
 DROP ROLE IF EXISTS nosuper;

--- a/regress/expected/nosuper_1.out
+++ b/regress/expected/nosuper_1.out
@@ -21,11 +21,7 @@ GRANT USAGE ON SCHEMA repack TO nosuper;
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
 INFO: repacking table "public.tbl_cluster"
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR:  permission denied for relation tbl_cluster
+WARNING: lock_exclusive() failed for public.tbl_cluster
 ERROR:  permission denied for relation tbl_cluster
 REVOKE ALL ON ALL TABLES IN SCHEMA repack FROM nosuper;
 REVOKE USAGE ON SCHEMA repack FROM nosuper;

--- a/regress/expected/repack-run.out
+++ b/regress/expected/repack-run.out
@@ -5,10 +5,10 @@
 INFO: repacking table "public.tbl_cluster"
 \! pg_repack --dbname=contrib_regression --table=tbl_badindex
 INFO: repacking table "public.tbl_badindex"
-WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 \! pg_repack --dbname=contrib_regression
 INFO: repacking table "public.tbl_badindex"
-WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 INFO: repacking table "public.tbl_cluster"
 INFO: repacking table "public.tbl_gistkey"
 INFO: repacking table "public.tbl_idxopts"

--- a/regress/sql/no-error-on-invalid-idx.sql
+++ b/regress/sql/no-error-on-invalid-idx.sql
@@ -1,0 +1,7 @@
+--
+-- do repack
+--
+
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-error-on-invalid-index
+\! pg_repack --dbname=contrib_regression --table=tbl_badindex --no-error-on-invalid-index
+\! pg_repack --dbname=contrib_regression --no-error-on-invalid-index

--- a/regress/sql/nosuper.sql
+++ b/regress/sql/nosuper.sql
@@ -11,4 +11,13 @@ CREATE ROLE nosuper WITH LOGIN;
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
+
+GRANT ALL ON ALL TABLES IN SCHEMA repack TO nosuper;
+GRANT USAGE ON SCHEMA repack TO nosuper;
+
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
+
+REVOKE ALL ON ALL TABLES IN SCHEMA repack FROM nosuper;
+REVOKE USAGE ON SCHEMA repack FROM nosuper;
 DROP ROLE IF EXISTS nosuper;


### PR DESCRIPTION
Free up space early to improve the overhead for repacking large tables. Preserve ordering by `relname, schemaname` for tests if `MAKELEVEL` is defined.

The following graph shows the size of `base` as reported by du(1) for the duration of `pg_repack -j2 -a`. By repacking small tables first, very little free may be required.

![pg_repack_sort](https://github.com/user-attachments/assets/0db99dee-3631-41d0-ae02-4e9f99cad7bb)